### PR TITLE
Feature/tmw instanceimage tickforward fix

### DIFF
--- a/ubcv/LArCVImageMaker/Instance2Image.cxx
+++ b/ubcv/LArCVImageMaker/Instance2Image.cxx
@@ -33,7 +33,7 @@ namespace supera {
     std::vector<larcv::Image2D> ancestor_v; // Filling ancestor ID per pixel
     std::vector<larcv::Image2D> energy_v;   // largest energy deposition
     for ( auto const& meta : meta_v ) {
-      LARCV_SINFO() << meta.dump();      
+      //LARCV_SINFO() << meta.dump() << std::endl;
       larcv::Image2D img1(meta);
       img1.paint(-1.0);
       img_v.emplace_back( std::move(img1) );

--- a/ubcv/LArCVImageMaker/Instance2Image.cxx
+++ b/ubcv/LArCVImageMaker/Instance2Image.cxx
@@ -130,8 +130,10 @@ namespace supera {
       const larcv::ImageMeta& meta = img.meta();
       larcv::ImageMeta meta_out(meta.width(), meta.height(), 
 				int( meta.rows()/row_compression_factor.at(meta.plane()) ), int( meta.cols()/col_compression_factor.at(meta.plane()) ),
-				meta.min_x(), meta.max_y(), 
+				meta.min_x(), meta.min_y(), 
 				meta.plane() );
+      LARCV_SINFO() << "output meta: " << std::endl;
+      LARCV_SINFO() << meta_out.dump() << std::endl;
       larcv::Image2D img_out( meta_out );
       img_out.paint(-1.0);
       img_out_v.emplace_back( std::move(img_out) );


### PR DESCRIPTION
While validating the output of the new uboonecode release v10_04_07_01, it was noticed that the imagemeta which provides the map between pixel (row,col) coordinates to (tick,wire) coordinates for certain truth images were incorrect.  This was because the module to make this image was not updated for the fact that we now save images in tick-forward order. The meta was defined for the previous tick-backward behavior. 

This is now fixed. And the image meta that is now saved has been visually confirmed as correct.