### PR TITLE
Add CRT and opflash data products to merged_dlreco.root files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 
 find_package(cetmodules REQUIRED)
-project(ubcv VERSION 10.04.07.01 LANGUAGES CXX)
+project(ubcv VERSION 10.04.08 LANGUAGES CXX)
 
 include(CetCMakeEnv)
 cet_cmake_env()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 
 find_package(cetmodules REQUIRED)
-project(ubcv VERSION 10.04.07.02 LANGUAGES CXX)
+project(ubcv VERSION 10.04.07.01 LANGUAGES CXX)
 
 include(CetCMakeEnv)
 cet_cmake_env()

--- a/ubcv/LArCVImageMaker/mcc10_prod_scripts/mcc10_dlreco_w_wirecell_driver_data_gen2.fcl
+++ b/ubcv/LArCVImageMaker/mcc10_prod_scripts/mcc10_dlreco_w_wirecell_driver_data_gen2.fcl
@@ -3,7 +3,7 @@
 #include "microboone_crt_file_manager.fcl"
 #include "microboone_crt_merger.fcl"
 #include "crtflashana.fcl"
-#include "reco_uboone_data_mcc9_8.fcl"
+#include "reco_uboone_data_mcc9_10.fcl"
 ##include "microboone_ubdl_module.fcl"
 #include "time_memory_tracker_microboone.fcl"
 
@@ -107,6 +107,9 @@ physics:
    wctagger: @local::litedata_wctagger
  }
  
+ reco: [ "rns", "wcopflash","crtt0Correction","crthitcorrFirstPass","crthitcorr","crttzero","crttrack" ]
+ trigger_paths: [ reco]
+
  #dlnetpath: [ophitBeamCalib,ophitCosmicCalib,simpleFlashBeam,simpleFlashCosmic,merger,mergerextra,crthitcorr,crttzero,crttrack,ubdl]
  #stream: [opreco, reco2d, wctagger, out1]
  stream: [opreco, superaData, out1]
@@ -163,6 +166,7 @@ outputs:
    compressionLevel: 1
    saveMemoryObjectThreshold: 0
    fileName:    "%ifb_%tc_ubdl.root" #default file name, can override from command line with -o or --output
+   outputCommands: ["keep *_*_*_*", "drop *_*_*_DLWCDeploy"]
  }
 }
 

--- a/ubcv/LArCVImageMaker/mcc10_prod_scripts/mcc10_dlreco_w_wirecell_driver_overlay_and_mc_gen2.fcl
+++ b/ubcv/LArCVImageMaker/mcc10_prod_scripts/mcc10_dlreco_w_wirecell_driver_overlay_and_mc_gen2.fcl
@@ -1,6 +1,7 @@
 #include "dlprod_fclbase_producers.fcl"
 #include "dlprod_fclbase_analyzers_gen2.fcl"
 #include "time_memory_tracker_microboone.fcl"
+#include "reco_uboone_data_mcc9_10.fcl"
 
 BEGIN_PROLOG
 
@@ -23,6 +24,7 @@ services:
   scheduler:    { defaultExceptions: false }
   #TimeTracker:             @local::microboone_time_tracker
   MemoryTracker:           @local::microboone_memory_tracker
+  RandomNumberGenerator:   {} #ART native random number generator
   message:                 @local::microboone_message_services_prod_debug
   FileCatalogMetadata:     @local::art_file_catalog_data
   @table::microboone_services_reco
@@ -66,6 +68,7 @@ physics:
 {
  producers: {
    @table::dlprod_producers
+   @table::microboone_reco_data_producers
    #ubdl: @local::microboone_ubdl
  }
 
@@ -75,6 +78,9 @@ physics:
    @table::dlprod_analyzers
    wctagger: @local::litedata_wctagger
  }
+
+ reco: [ "rns", "wcopflash","crtt0Correction","crthitcorrFirstPass","crthitcorr","crttzero","crttrack" ]
+ trigger_paths: [ reco]
 
  #dlnetpath: [ubdl]
  #stream: [opreco, reco2d, mcinfo, gaushitMCinfoBacktracker, wctagger, superaMCTruthOnly, out1]
@@ -125,6 +131,7 @@ outputs:
    compressionLevel: 1
    saveMemoryObjectThreshold: 0
    fileName:    "%ifb_%tc_ubdl.root" #default file name, can override from command line with -o or --output
+   outputCommands: ["keep *_*_*_*", "drop *_*_*_DLDeploy"]
  }
 }
 

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -249,8 +249,8 @@ fwdir	product_dir	scripts
 ####################################
 product		version		qual	flags		<table_format=2>
 ubdl		v2_me_06_03	-       optional
-ubevt		v10_04_05	-
-ubreco          v10_04_07_01    -
+ubevt		v10_04_08	-
+ubreco          v10_04_08    -
 cetmodules	v3_24_01	-	only_for_build
 end_product_list
 ####################################

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -250,7 +250,7 @@ fwdir	product_dir	scripts
 product		version		qual	flags		<table_format=2>
 ubdl		v2_me_06_03	-       optional
 ubevt		v10_04_05	-
-ubreco          v10_04_07_02    -
+ubreco          v10_04_07_01    -
 cetmodules	v3_24_01	-	only_for_build
 end_product_list
 ####################################


### PR DESCRIPTION
This pull request modifies the fcls that produce merged_dlreco.root files needed for the full lantern workflow and the LArPID/MC backtracking integration into Wire-Cell.

Additional larsoft producer modules are run to create the CRT and opflash data products that this fcl attempts to read in and write to output "larlite" trees in the merged_dlreco.root files. Formerly, the module that attempted to read these products output a warning message stating that the products couldn't be found, and the output CRT and opflash larlite trees were empty.

The fcls have also been updated to drop these newly created CRT and opflash data products from the artroot files after writing this data to the output merged_dlreco.root files. Therefore the artroot file produced by running these fcls is not altered in any way by this pull request, so there should be no impact to the Wire-Cell or unified workflows. The only change is that the CRT and opflash larlite trees in the merged_dlreco.root files will now be filled.