### PR TITLE
lantern metadata fix

### DIFF
--- a/ubcv/LArCVImageMaker/mcc10_prod_scripts/copy_nonartroot_lantern.fcl
+++ b/ubcv/LArCVImageMaker/mcc10_prod_scripts/copy_nonartroot_lantern.fcl
@@ -21,7 +21,7 @@ microboone_tfile_metadata:
 {
   JSONFileName: [ "larflowreco_kpsrecomanagerana.root.json", "flat_ntuple.root.json" ]
   GenerateTFileMetadata: [ true, true ]
-  dataTier:              [ "larflowreco_kpsrecomanagerana", "flat_ntuple" ]
+  dataTier:              [ "lanternreco", "flat_ntuple" ]
   fileFormat:            [ "root", "root" ]
 }
 

--- a/ubcv/LArCVImageMaker/mcc10_prod_scripts/define_metadata_lantern.fcl
+++ b/ubcv/LArCVImageMaker/mcc10_prod_scripts/define_metadata_lantern.fcl
@@ -16,6 +16,24 @@ source:
   maxEvents:   -1        # Number of events to read
 }
 
+physics:
+{
+  stream: [out1]
+  end_paths: [stream]
+}
+
+outputs:
+{
+ out1:
+ {
+   module_type: RootOutput
+   dataTier: "reconstructed"
+   compressionLevel: 1
+   saveMemoryObjectThreshold: 0
+   fileName:    "%ifb_%tc_copy.root" #default file name, can override from command line with -o or --output
+ }
+}
+
 # Configuration for TFileMetadataMicroBooNE service
 microboone_tfile_metadata:
 {

--- a/ubcv/LArCVImageMaker/mcc10_prod_scripts/define_metadata_lantern.fcl
+++ b/ubcv/LArCVImageMaker/mcc10_prod_scripts/define_metadata_lantern.fcl
@@ -21,7 +21,7 @@ microboone_tfile_metadata:
 {
   JSONFileName: [ "larflowreco_kpsrecomanagerana.root.json", "flat_ntuple.root.json" ]
   GenerateTFileMetadata: [ true, true ]
-  dataTier:              [ "larflowreco_kpsrecomanagerana", "flat_ntuple" ]
+  dataTier:              [ "lanternreco", "flat_ntuple" ]
   fileFormat:            [ "root", "root" ]
 }
 


### PR DESCRIPTION
This PR updates the data tier metadata field for lantern's reco ana files to something that now actually exists in SAM so they can be declared properly.