### PR TITLE
Fix for missing LANTERN events in unified ntuples

### DIFF
--- a/ubcv/LArCVImageMaker/mcc10_prod_scripts/launch_lantern_container_data.sh
+++ b/ubcv/LArCVImageMaker/mcc10_prod_scripts/launch_lantern_container_data.sh
@@ -6,4 +6,38 @@ echo "executing run script from cvmfs lantern container"
 
 echo "Container exited with code $?"
 
+echo "Checking output lantern ntuple"
+
+#make simple root macro to validate lantern ntuple
+cat << 'EOF' > check_lantern.C
+void check_lantern() {
+    TFile *f = TFile::Open("flat_ntuple.root");
+    if (!f || f->IsZombie()) {
+        std::cerr << "lantern ntuple is missing or corrupted" << std::endl;
+        gSystem->Exit(1);
+    }
+    TTree *tree = (TTree*)f->Get("EventTree");
+    if (!tree) {
+        std::cerr << "EventTree not found in lantern ntuple" << std::endl;
+        gSystem->Exit(1);
+    }
+    f->Close();
+    gSystem->Exit(0);
+}
+EOF
+
+#run check lantern macro
+root -l -b -q check_lantern.C
+status=$?
+#clean up
+rm check_lantern.C
+
+#force job crash if lantern ntuple is missing/corrupted
+if [ $status -ne 0 ]; then
+    echo "detected lantern ntuple file error; exiting with code 1"
+    exit 1
+else
+    echo "lantern ntuple file validation passed"
+fi
+
 echo "Done!"

--- a/ubcv/LArCVImageMaker/mcc10_prod_scripts/launch_lantern_container_data_unified.sh
+++ b/ubcv/LArCVImageMaker/mcc10_prod_scripts/launch_lantern_container_data_unified.sh
@@ -6,6 +6,40 @@ echo "executing run script from cvmfs lantern container"
 
 echo "Container exited with code $?"
 
+echo "Checking output lantern ntuple"
+
+#make simple root macro to validate lantern ntuple
+cat << 'EOF' > check_lantern.C
+void check_lantern() {
+    TFile *f = TFile::Open("flat_ntuple.root");
+    if (!f || f->IsZombie()) {
+        std::cerr << "lantern ntuple is missing or corrupted" << std::endl;
+        gSystem->Exit(1);
+    }
+    TTree *tree = (TTree*)f->Get("EventTree");
+    if (!tree) {
+        std::cerr << "EventTree not found in lantern ntuple" << std::endl;
+        gSystem->Exit(1);
+    }
+    f->Close();
+    gSystem->Exit(0);
+}
+EOF
+
+#run check lantern macro
+root -l -b -q check_lantern.C
+status=$?
+#clean up
+rm check_lantern.C
+
+#force job crash if lantern ntuple is missing/corrupted
+if [ $status -ne 0 ]; then
+    echo "detected lantern ntuple file error; exiting with code 1"
+    exit 1
+else
+    echo "lantern ntuple file validation passed"
+fi
+
 echo "Merging lantern ntuple into unified ntuple"
 
 unified_ntuple=$(find . -maxdepth 1 -type f -name 'reco_stage_2_hist*.root' -printf '%f\n' -quit)

--- a/ubcv/LArCVImageMaker/mcc10_prod_scripts/launch_lantern_container_mc.sh
+++ b/ubcv/LArCVImageMaker/mcc10_prod_scripts/launch_lantern_container_mc.sh
@@ -6,4 +6,38 @@ echo "executing run script from cvmfs lantern container"
 
 echo "Container exited with code $?"
 
+echo "Checking output lantern ntuple"
+
+#make simple root macro to validate lantern ntuple
+cat << 'EOF' > check_lantern.C
+void check_lantern() {
+    TFile *f = TFile::Open("flat_ntuple.root");
+    if (!f || f->IsZombie()) {
+        std::cerr << "lantern ntuple is missing or corrupted" << std::endl;
+        gSystem->Exit(1);
+    }
+    TTree *tree = (TTree*)f->Get("EventTree");
+    if (!tree) {
+        std::cerr << "EventTree not found in lantern ntuple" << std::endl;
+        gSystem->Exit(1);
+    }
+    f->Close();
+    gSystem->Exit(0);
+}
+EOF
+
+#run check lantern macro
+root -l -b -q check_lantern.C
+status=$?
+#clean up
+rm check_lantern.C
+
+#force job crash if lantern ntuple is missing/corrupted
+if [ $status -ne 0 ]; then
+    echo "detected lantern ntuple file error; exiting with code 1"
+    exit 1
+else
+    echo "lantern ntuple file validation passed"
+fi
+
 echo "Done!"

--- a/ubcv/LArCVImageMaker/mcc10_prod_scripts/launch_lantern_container_mc_altLArPIDWeights.sh
+++ b/ubcv/LArCVImageMaker/mcc10_prod_scripts/launch_lantern_container_mc_altLArPIDWeights.sh
@@ -6,4 +6,38 @@ echo "executing run script from cvmfs lantern container"
 
 echo "Container exited with code $?"
 
+echo "Checking output lantern ntuple"
+
+#make simple root macro to validate lantern ntuple
+cat << 'EOF' > check_lantern.C
+void check_lantern() {
+    TFile *f = TFile::Open("flat_ntuple.root");
+    if (!f || f->IsZombie()) {
+        std::cerr << "lantern ntuple is missing or corrupted" << std::endl;
+        gSystem->Exit(1);
+    }
+    TTree *tree = (TTree*)f->Get("EventTree");
+    if (!tree) {
+        std::cerr << "EventTree not found in lantern ntuple" << std::endl;
+        gSystem->Exit(1);
+    }
+    f->Close();
+    gSystem->Exit(0);
+}
+EOF
+
+#run check lantern macro
+root -l -b -q check_lantern.C
+status=$?
+#clean up
+rm check_lantern.C
+
+#force job crash if lantern ntuple is missing/corrupted
+if [ $status -ne 0 ]; then
+    echo "detected lantern ntuple file error; exiting with code 1"
+    exit 1
+else
+    echo "lantern ntuple file validation passed"
+fi
+
 echo "Done!"

--- a/ubcv/LArCVImageMaker/mcc10_prod_scripts/launch_lantern_container_mc_unified.sh
+++ b/ubcv/LArCVImageMaker/mcc10_prod_scripts/launch_lantern_container_mc_unified.sh
@@ -6,6 +6,40 @@ echo "executing run script from cvmfs lantern container"
 
 echo "Container exited with code $?"
 
+echo "Checking output lantern ntuple"
+
+#make simple root macro to validate lantern ntuple
+cat << 'EOF' > check_lantern.C
+void check_lantern() {
+    TFile *f = TFile::Open("flat_ntuple.root");
+    if (!f || f->IsZombie()) {
+        std::cerr << "lantern ntuple is missing or corrupted" << std::endl;
+        gSystem->Exit(1);
+    }
+    TTree *tree = (TTree*)f->Get("EventTree");
+    if (!tree) {
+        std::cerr << "EventTree not found in lantern ntuple" << std::endl;
+        gSystem->Exit(1);
+    }
+    f->Close();
+    gSystem->Exit(0);
+}
+EOF
+
+#run check lantern macro
+root -l -b -q check_lantern.C
+status=$?
+#clean up
+rm check_lantern.C
+
+#force job crash if lantern ntuple is missing/corrupted
+if [ $status -ne 0 ]; then
+    echo "detected lantern ntuple file error; exiting with code 1"
+    exit 1
+else
+    echo "lantern ntuple file validation passed"
+fi
+
 echo "Merging lantern ntuple into unified ntuple"
 
 unified_ntuple=$(find . -maxdepth 1 -type f -name 'reco_stage_2_hist*.root' -printf '%f\n' -quit)

--- a/ubcv/LArCVImageMaker/mcc10_prod_scripts/launch_lantern_container_mc_unified_altLArPIDWeights.sh
+++ b/ubcv/LArCVImageMaker/mcc10_prod_scripts/launch_lantern_container_mc_unified_altLArPIDWeights.sh
@@ -6,6 +6,40 @@ echo "executing run script from cvmfs lantern container"
 
 echo "Container exited with code $?"
 
+echo "Checking output lantern ntuple"
+
+#make simple root macro to validate lantern ntuple
+cat << 'EOF' > check_lantern.C
+void check_lantern() {
+    TFile *f = TFile::Open("flat_ntuple.root");
+    if (!f || f->IsZombie()) {
+        std::cerr << "lantern ntuple is missing or corrupted" << std::endl;
+        gSystem->Exit(1);
+    }
+    TTree *tree = (TTree*)f->Get("EventTree");
+    if (!tree) {
+        std::cerr << "EventTree not found in lantern ntuple" << std::endl;
+        gSystem->Exit(1);
+    }
+    f->Close();
+    gSystem->Exit(0);
+}
+EOF
+
+#run check lantern macro
+root -l -b -q check_lantern.C
+status=$?
+#clean up
+rm check_lantern.C
+
+#force job crash if lantern ntuple is missing/corrupted
+if [ $status -ne 0 ]; then
+    echo "detected lantern ntuple file error; exiting with code 1"
+    exit 1
+else
+    echo "lantern ntuple file validation passed"
+fi
+
 echo "Merging lantern ntuple into unified ntuple"
 
 unified_ntuple=$(find . -maxdepth 1 -type f -name 'reco_stage_2_hist*.root' -printf '%f\n' -quit)


### PR DESCRIPTION
This PR provides a fix for the lantern missing events issue by forcing grid jobs to fail in the very rare cases where there's a fatal error inside the lantern container.

There is a very rare issue (occurred just once in a test sample of 30,000 events) where a lantern script seg faults, but since this happens inside the lantern container in a script launched with apptainer exec, this won't cause grid jobs to fail. Instead, a corrupted output lantern ntuple is produced, which can't be merged into the unified ntuple. So after file merging, events from this job will be missing from the lantern tree in the unified ntuple and entries won't sync up with the Wire Cell and Pandora trees.

I will provide a fix to the underlying seg fault issue in the near future. This patch will simply crash the extremely rare jobs where the error is encountered so that we don't get pandora and wire-cell events in the unified ntuple when there are no corresponding lantern events.