### PR TITLE
Add double pmt and run 1ab versions of dlreco fcls.

### DIFF
--- a/ubcv/LArCVImageMaker/mcc10_prod_scripts/mcc10_dlreco_w_wirecell_driver_data_double_pmt_lantern.fcl
+++ b/ubcv/LArCVImageMaker/mcc10_prod_scripts/mcc10_dlreco_w_wirecell_driver_data_double_pmt_lantern.fcl
@@ -1,0 +1,4 @@
+#include "mcc10_dlreco_w_wirecell_driver_data_lantern.fcl"
+
+# configure optical producers:
+physics.producers.saturation.HGProducer:           "doublePMTFilter"

--- a/ubcv/LArCVImageMaker/mcc10_prod_scripts/mcc10_dlreco_w_wirecell_driver_data_run1ab_lantern.fcl
+++ b/ubcv/LArCVImageMaker/mcc10_prod_scripts/mcc10_dlreco_w_wirecell_driver_data_run1ab_lantern.fcl
@@ -1,0 +1,7 @@
+#include "mcc10_dlreco_w_wirecell_driver_data_lantern.fcl"
+
+# configure optical producers:
+physics.producers.saturation.HGProducer:           "doublePMTFilter"
+physics.producers.saturation.HGProducerCosmic:     "cosmicPMTFilter"
+physics.producers.wcopflash.OpDataProducerBeam:    "doublePMTFilter"
+physics.producers.wcopflash.OpDataProducerCosmic:  "cosmicPMTFilter"


### PR DESCRIPTION
Add fcls to read proper versions of raw optical waveforms.