### PR TITLE
memory requirement reduction for fcl that produces larcv images

### DIFF
--- a/ubcv/LArCVImageMaker/mcc10_prod_scripts/dlprod_fclbase_analyzers_gen2.fcl
+++ b/ubcv/LArCVImageMaker/mcc10_prod_scripts/dlprod_fclbase_analyzers_gen2.fcl
@@ -65,6 +65,22 @@ SuperaMCTruthOnly.supera_params: "supera_mctruthonly.fcl"
 SuperaMCTruth: @local::SuperaWholeView
 SuperaMCTruth.supera_params: "supera_mctruth_w_wcthrumu.fcl"
 
+SuperaMCTruth2: @local::SuperaWholeView
+SuperaMCTruth2.supera_params: "supera_mctruth_set2.fcl"
+SuperaMCTruth2.out_filename: "larcv_mc2.root"
+
+SuperaMCTruth3: @local::SuperaWholeView
+SuperaMCTruth3.supera_params: "supera_mctruth_set3.fcl"
+SuperaMCTruth3.out_filename: "larcv_mc3.root"
+
+SuperaMCTruth4: @local::SuperaWholeView
+SuperaMCTruth4.supera_params: "supera_mctruth_set4.fcl"
+SuperaMCTruth4.out_filename: "larcv_mc4.root"
+
+SuperaMCTruth5: @local::SuperaWholeView
+SuperaMCTruth5.supera_params: "supera_mctruth_set5.fcl"
+SuperaMCTruth5.out_filename: "larcv_mc5.root"
+
 SuperaData: @local::SuperaWholeView
 SuperaData.supera_params: "supera_data_w_wcthrumu.fcl"
 
@@ -100,6 +116,10 @@ dlprod_analyzers:
    superaMCBasic:     @local::SuperaMCBasic
    superaMCTruthOnly: @local::SuperaMCTruthOnly
    superaMCTruth: @local::SuperaMCTruth
+   superaMCTruth2: @local::SuperaMCTruth2
+   superaMCTruth3: @local::SuperaMCTruth3
+   superaMCTruth4: @local::SuperaMCTruth4
+   superaMCTruth5: @local::SuperaMCTruth5
    superaData: @local::SuperaData
    superaWire: @local::SuperaWire
 }

--- a/ubcv/LArCVImageMaker/mcc10_prod_scripts/mcc10_dlreco_w_wirecell_driver_overlay_lantern_set1.fcl
+++ b/ubcv/LArCVImageMaker/mcc10_prod_scripts/mcc10_dlreco_w_wirecell_driver_overlay_lantern_set1.fcl
@@ -1,0 +1,171 @@
+#include "dlprod_fclbase_producers.fcl"
+#include "dlprod_fclbase_analyzers_gen2.fcl"
+#include "time_memory_tracker_microboone.fcl"
+#include "reco_uboone_data_mcc9_10.fcl"
+
+## To see example workflow context for this driver see: 
+## https://cdcvs.fnal.gov/redmine/projects/uboone-physics-analysis/wiki/MCC10_Release_Page#Data-Beam-On-NuMI
+
+BEGIN_PROLOG
+
+litedata_wctagger: @local::litemaker_base
+litedata_wctagger.out_filename: "larlite_wctagger.root"
+litedata_wctagger.DataLookUpMap:
+{
+  sps : [ "portedSpacePointsThreshold" ]
+  hit : [ "portedThresholdhit" ]
+}
+
+END_PROLOG
+
+
+process_name: DLDeploy
+
+services:
+{
+  TFileService: { fileName: "larcv_hist.root" }  
+  scheduler:    { defaultExceptions: false }
+  #TimeTracker:             @local::microboone_time_tracker
+  MemoryTracker:           @local::microboone_memory_tracker
+  RandomNumberGenerator:   {} #ART native random number generator
+  message:                 @local::microboone_message_services_prod_debug
+  FileCatalogMetadata:     @local::art_file_catalog_data
+  @table::microboone_services_reco
+}
+
+#services.TimeTracker.printSummary: false
+#services.TimeTracker.dbOutput: {}
+#services.MemoryTracker.printSummaries: []
+#services.MemoryTracker.includeMallocInfo: false
+
+services.DetectorClocksService.TrigModuleName: "daq"  # note that the clock time needed for the flash timing proper reconstruction
+services.DetectorPropertiesService.NumberTimeSamples:        6400
+services.DetectorPropertiesService.ReadOutWindowSize:        6400
+services.DetectorClocksService.InheritClockConfig:           false
+services.DetectorClocksService.TriggerOffsetTPC:             -0.400e3
+services.FileCatalogMetadata.fileType: "overlay"
+services.SpaceCharge.EnableSimSpatialSCE: true
+services.SpaceCharge.EnableSimEfieldSCE:  true
+services.LLMetaMaker: {Enable: false}
+services.LArCVMetaMaker: {Enable: false}
+
+source:
+{
+  module_type: RootInput
+  maxEvents:   -1        # Number of events to read
+}
+
+source_gen:
+{
+  module_type: EmptyEvent
+  timestampPlugin: { plugin_type: "GeneratedEventTimestamp" }
+  maxEvents:   10          # Number of events to create
+  firstRun:    1        # Run number to use for this file
+  firstEvent:  1           # number of first event in the file
+}
+
+source_reprocess:
+{
+  module_type: RootInput
+  maxEvents:   100000     # Number of events to create
+}
+
+
+# drop past optical products
+source.inputCommands: ["keep *_*_*_*"]
+#                       "drop *_*_*_Data*RecoStage2", 
+#                       "drop *_*_*_MC*RecoStage2"]
+
+physics:
+{
+ producers: {
+   @table::dlprod_producers
+   @table::microboone_reco_data_producers
+   #ubdl: @local::microboone_ubdl
+ }
+
+ filters: {
+   @table::microboone_reco_data_filters
+ }
+
+ analyzers: {
+   @table::dlprod_analyzers
+   wctagger: @local::litedata_wctagger
+ }
+
+ reco: [ @sequence::microboone_reco_data_optical, 
+         "wcopflash",
+         "rns", 
+         "crtt0Correction",
+         "crthitcorrFirstPass",
+         "crthitcorr",
+         "crttzero",
+         "crttrack"]
+         #"opfiltercommonext" ]
+ trigger_paths: [reco]
+
+
+ #dlnetpath: [ubdl]
+ #stream: [opreco, reco2d, mcinfo, gaushitMCinfoBacktracker, wctagger, superaMCTruthOnly, out1]
+ #stream: [opreco, mcinfo, wctagger, superaMCTruth]
+ #stream: [opreco, mcinfo, superaMCTruth, out1]
+ stream: [opreco, mcinfo, superaData, out1]
+ end_paths: [stream]
+ #trigger_paths: [ dlnetpath ]
+}
+
+outputs:
+{
+ out1:
+ {
+   module_type: RootOutput
+   dataTier: "reconstructed"
+   compressionLevel: 1
+   saveMemoryObjectThreshold: 0
+   fileName:    "%ifb_%tc_ubdl.root" #default file name, can override from command line with -o or --output
+   outputCommands: ["keep *_*_*_*", "drop *_*_*_DLDeploy"]
+   #outputCommands: ["keep *_*_*_*"]
+ }
+}
+
+# Configuration for TFileMetadataMicroBooNE service
+microboone_tfile_metadata:
+{
+  JSONFileName: [ "merged_dlreco.root.json" ]
+  GenerateTFileMetadata: [ true ]
+  dataTier:              [ "merged_dlreco" ]
+  fileFormat:            [ "root" ]
+}
+
+# Turn on Mask-RCNN
+#physics.producers.ubdl.CosmicMRCNNMode: "PyTorchCPU"
+
+# configure reco producers:
+physics.producers.saturation.HGProducer: "mixer"
+physics.producers.saturation.LGProducer: "mixer"
+physics.producers.wcopflash.OpDataProducerBeam: "mixer"
+physics.filters.crtveto: @local::UBCRTCosmicFilterBNBOFF
+physics.producers.crthitcorrFirstPass.IsOverlay: true
+physics.producers.crthitcorr.CrtHitsIn_Label1: "crthitcorrFirstPass"
+
+# configure larlite
+# -- trigger --
+# MC
+physics.analyzers.opreco.DataLookUpMap.trigger: ["triggersim"]
+# -- CRT --
+physics.analyzers.opreco.DataLookUpMap.crthit:   ["crthitcorr"]
+physics.analyzers.opreco.DataLookUpMap.crttrack: ["crttrack"]
+physics.analyzers.opreco.DataLookUpMap.daqheadertimeuboone: ["daq"]
+physics.analyzers.opreco.DAQHeaderProducer: "daq"
+physics.analyzers.opreco.DAQHeaderTimeUBProducer: "daq"
+
+physics.analyzers.opreco.DataLookUpMap.opflash: ["simpleFlashBeam","simpleFlashCosmic","wcopflash:beam","wcopflash:cosmic"]
+physics.analyzers.opreco.DataLookUpMap.opdigit: ["wcopflash:MergedBeam","wcopflash:MergedCosmic"]
+physics.analyzers.opreco.DataLookUpMap.ophit: []
+physics.analyzers.opreco.AssociationLookUpMap.ophit: []
+physics.analyzers.opreco.AssociationLookUpMap.opflash: []
+physics.analyzers.mcinfo.DataLookUpMap.mceventweight: []
+#physics.analyzers.opreco.DataLookUpMap.ophit: ["ophitBeamNoRemap::DLDeploy","ophitBeam::DLDeploy","ophitBeamCalib::DLDeploy","ophitCosmicCalib::DLDeploy"]
+
+# configure truth supera
+#physics.analyzers.superaMCTruth.supera_params: "supera_mctruth_no_wcthrumu.fcl" # for no-WC debug only

--- a/ubcv/LArCVImageMaker/mcc10_prod_scripts/mcc10_dlreco_w_wirecell_driver_overlay_lantern_set2.fcl
+++ b/ubcv/LArCVImageMaker/mcc10_prod_scripts/mcc10_dlreco_w_wirecell_driver_overlay_lantern_set2.fcl
@@ -1,0 +1,171 @@
+#include "dlprod_fclbase_producers.fcl"
+#include "dlprod_fclbase_analyzers_gen2.fcl"
+#include "time_memory_tracker_microboone.fcl"
+#include "reco_uboone_data_mcc9_10.fcl"
+
+## To see example workflow context for this driver see: 
+## https://cdcvs.fnal.gov/redmine/projects/uboone-physics-analysis/wiki/MCC10_Release_Page#Data-Beam-On-NuMI
+
+BEGIN_PROLOG
+
+litedata_wctagger: @local::litemaker_base
+litedata_wctagger.out_filename: "larlite_wctagger.root"
+litedata_wctagger.DataLookUpMap:
+{
+  sps : [ "portedSpacePointsThreshold" ]
+  hit : [ "portedThresholdhit" ]
+}
+
+END_PROLOG
+
+
+process_name: DLDeployMC2
+
+services:
+{
+  TFileService: { fileName: "larcv_hist.root" }  
+  scheduler:    { defaultExceptions: false }
+  #TimeTracker:             @local::microboone_time_tracker
+  MemoryTracker:           @local::microboone_memory_tracker
+  RandomNumberGenerator:   {} #ART native random number generator
+  message:                 @local::microboone_message_services_prod_debug
+  FileCatalogMetadata:     @local::art_file_catalog_data
+  @table::microboone_services_reco
+}
+
+#services.TimeTracker.printSummary: false
+#services.TimeTracker.dbOutput: {}
+#services.MemoryTracker.printSummaries: []
+#services.MemoryTracker.includeMallocInfo: false
+
+services.DetectorClocksService.TrigModuleName: "daq"  # note that the clock time needed for the flash timing proper reconstruction
+services.DetectorPropertiesService.NumberTimeSamples:        6400
+services.DetectorPropertiesService.ReadOutWindowSize:        6400
+services.DetectorClocksService.InheritClockConfig:           false
+services.DetectorClocksService.TriggerOffsetTPC:             -0.400e3
+services.FileCatalogMetadata.fileType: "overlay"
+services.SpaceCharge.EnableSimSpatialSCE: true
+services.SpaceCharge.EnableSimEfieldSCE:  true
+services.LLMetaMaker: {Enable: false}
+services.LArCVMetaMaker: {Enable: false}
+
+source:
+{
+  module_type: RootInput
+  maxEvents:   -1        # Number of events to read
+}
+
+source_gen:
+{
+  module_type: EmptyEvent
+  timestampPlugin: { plugin_type: "GeneratedEventTimestamp" }
+  maxEvents:   10          # Number of events to create
+  firstRun:    1        # Run number to use for this file
+  firstEvent:  1           # number of first event in the file
+}
+
+source_reprocess:
+{
+  module_type: RootInput
+  maxEvents:   100000     # Number of events to create
+}
+
+
+# drop past optical products
+source.inputCommands: ["keep *_*_*_*"]
+#                       "drop *_*_*_Data*RecoStage2", 
+#                       "drop *_*_*_MC*RecoStage2"]
+
+physics:
+{
+ producers: {
+   @table::dlprod_producers
+   @table::microboone_reco_data_producers
+   #ubdl: @local::microboone_ubdl
+ }
+
+ filters: {
+   @table::microboone_reco_data_filters
+ }
+
+ analyzers: {
+   @table::dlprod_analyzers
+   wctagger: @local::litedata_wctagger
+ }
+
+ reco: [ @sequence::microboone_reco_data_optical, 
+         "wcopflash",
+         "rns", 
+         "crtt0Correction",
+         "crthitcorrFirstPass",
+         "crthitcorr",
+         "crttzero",
+         "crttrack"]
+         #"opfiltercommonext" ]
+ #trigger_paths: [reco]
+
+
+ #dlnetpath: [ubdl]
+ #stream: [opreco, reco2d, mcinfo, gaushitMCinfoBacktracker, wctagger, superaMCTruthOnly, out1]
+ #stream: [opreco, mcinfo, wctagger, superaMCTruth]
+ #stream: [opreco, mcinfo, superaMCTruth, out1]
+ stream: [superaMCTruth2, out1]
+ end_paths: [stream]
+ #trigger_paths: [ dlnetpath ]
+}
+
+outputs:
+{
+ out1:
+ {
+   module_type: RootOutput
+   dataTier: "reconstructed"
+   compressionLevel: 1
+   saveMemoryObjectThreshold: 0
+   fileName:    "%ifb_mc2.root" #default file name, can override from command line with -o or --output
+   outputCommands: ["keep *_*_*_*", "drop *_*_*_DLDeployMC2"]
+   #outputCommands: ["keep *_*_*_*"]
+ }
+}
+
+# Configuration for TFileMetadataMicroBooNE service
+microboone_tfile_metadata:
+{
+  JSONFileName: [ "merged_dlreco.root.json" ]
+  GenerateTFileMetadata: [ true ]
+  dataTier:              [ "merged_dlreco" ]
+  fileFormat:            [ "root" ]
+}
+
+# Turn on Mask-RCNN
+#physics.producers.ubdl.CosmicMRCNNMode: "PyTorchCPU"
+
+# configure reco producers:
+physics.producers.saturation.HGProducer: "mixer"
+physics.producers.saturation.LGProducer: "mixer"
+physics.producers.wcopflash.OpDataProducerBeam: "mixer"
+physics.filters.crtveto: @local::UBCRTCosmicFilterBNBOFF
+physics.producers.crthitcorrFirstPass.IsOverlay: true
+physics.producers.crthitcorr.CrtHitsIn_Label1: "crthitcorrFirstPass"
+
+# configure larlite
+# -- trigger --
+# MC
+physics.analyzers.opreco.DataLookUpMap.trigger: ["triggersim"]
+# -- CRT --
+physics.analyzers.opreco.DataLookUpMap.crthit:   ["crthitcorr"]
+physics.analyzers.opreco.DataLookUpMap.crttrack: ["crttrack"]
+physics.analyzers.opreco.DataLookUpMap.daqheadertimeuboone: ["daq"]
+physics.analyzers.opreco.DAQHeaderProducer: "daq"
+physics.analyzers.opreco.DAQHeaderTimeUBProducer: "daq"
+
+physics.analyzers.opreco.DataLookUpMap.opflash: ["simpleFlashBeam","simpleFlashCosmic","wcopflash:beam","wcopflash:cosmic"]
+physics.analyzers.opreco.DataLookUpMap.opdigit: ["wcopflash:MergedBeam","wcopflash:MergedCosmic"]
+physics.analyzers.opreco.DataLookUpMap.ophit: []
+physics.analyzers.opreco.AssociationLookUpMap.ophit: []
+physics.analyzers.opreco.AssociationLookUpMap.opflash: []
+physics.analyzers.mcinfo.DataLookUpMap.mceventweight: []
+#physics.analyzers.opreco.DataLookUpMap.ophit: ["ophitBeamNoRemap::DLDeploy","ophitBeam::DLDeploy","ophitBeamCalib::DLDeploy","ophitCosmicCalib::DLDeploy"]
+
+# configure truth supera
+#physics.analyzers.superaMCTruth.supera_params: "supera_mctruth_no_wcthrumu.fcl" # for no-WC debug only

--- a/ubcv/LArCVImageMaker/mcc10_prod_scripts/mcc10_dlreco_w_wirecell_driver_overlay_lantern_set3.fcl
+++ b/ubcv/LArCVImageMaker/mcc10_prod_scripts/mcc10_dlreco_w_wirecell_driver_overlay_lantern_set3.fcl
@@ -1,0 +1,171 @@
+#include "dlprod_fclbase_producers.fcl"
+#include "dlprod_fclbase_analyzers_gen2.fcl"
+#include "time_memory_tracker_microboone.fcl"
+#include "reco_uboone_data_mcc9_10.fcl"
+
+## To see example workflow context for this driver see: 
+## https://cdcvs.fnal.gov/redmine/projects/uboone-physics-analysis/wiki/MCC10_Release_Page#Data-Beam-On-NuMI
+
+BEGIN_PROLOG
+
+litedata_wctagger: @local::litemaker_base
+litedata_wctagger.out_filename: "larlite_wctagger.root"
+litedata_wctagger.DataLookUpMap:
+{
+  sps : [ "portedSpacePointsThreshold" ]
+  hit : [ "portedThresholdhit" ]
+}
+
+END_PROLOG
+
+
+process_name: DLDeployMC3
+
+services:
+{
+  TFileService: { fileName: "larcv_hist.root" }  
+  scheduler:    { defaultExceptions: false }
+  #TimeTracker:             @local::microboone_time_tracker
+  MemoryTracker:           @local::microboone_memory_tracker
+  RandomNumberGenerator:   {} #ART native random number generator
+  message:                 @local::microboone_message_services_prod_debug
+  FileCatalogMetadata:     @local::art_file_catalog_data
+  @table::microboone_services_reco
+}
+
+#services.TimeTracker.printSummary: false
+#services.TimeTracker.dbOutput: {}
+#services.MemoryTracker.printSummaries: []
+#services.MemoryTracker.includeMallocInfo: false
+
+services.DetectorClocksService.TrigModuleName: "daq"  # note that the clock time needed for the flash timing proper reconstruction
+services.DetectorPropertiesService.NumberTimeSamples:        6400
+services.DetectorPropertiesService.ReadOutWindowSize:        6400
+services.DetectorClocksService.InheritClockConfig:           false
+services.DetectorClocksService.TriggerOffsetTPC:             -0.400e3
+services.FileCatalogMetadata.fileType: "overlay"
+services.SpaceCharge.EnableSimSpatialSCE: true
+services.SpaceCharge.EnableSimEfieldSCE:  true
+services.LLMetaMaker: {Enable: false}
+services.LArCVMetaMaker: {Enable: false}
+
+source:
+{
+  module_type: RootInput
+  maxEvents:   -1        # Number of events to read
+}
+
+source_gen:
+{
+  module_type: EmptyEvent
+  timestampPlugin: { plugin_type: "GeneratedEventTimestamp" }
+  maxEvents:   10          # Number of events to create
+  firstRun:    1        # Run number to use for this file
+  firstEvent:  1           # number of first event in the file
+}
+
+source_reprocess:
+{
+  module_type: RootInput
+  maxEvents:   100000     # Number of events to create
+}
+
+
+# drop past optical products
+source.inputCommands: ["keep *_*_*_*"]
+#                       "drop *_*_*_Data*RecoStage2", 
+#                       "drop *_*_*_MC*RecoStage2"]
+
+physics:
+{
+ producers: {
+   @table::dlprod_producers
+   @table::microboone_reco_data_producers
+   #ubdl: @local::microboone_ubdl
+ }
+
+ filters: {
+   @table::microboone_reco_data_filters
+ }
+
+ analyzers: {
+   @table::dlprod_analyzers
+   wctagger: @local::litedata_wctagger
+ }
+
+ reco: [ @sequence::microboone_reco_data_optical, 
+         "wcopflash",
+         "rns", 
+         "crtt0Correction",
+         "crthitcorrFirstPass",
+         "crthitcorr",
+         "crttzero",
+         "crttrack"]
+         #"opfiltercommonext" ]
+ #trigger_paths: [reco]
+
+
+ #dlnetpath: [ubdl]
+ #stream: [opreco, reco2d, mcinfo, gaushitMCinfoBacktracker, wctagger, superaMCTruthOnly, out1]
+ #stream: [opreco, mcinfo, wctagger, superaMCTruth]
+ #stream: [opreco, mcinfo, superaMCTruth, out1]
+ stream: [superaMCTruth3, out1]
+ end_paths: [stream]
+ #trigger_paths: [ dlnetpath ]
+}
+
+outputs:
+{
+ out1:
+ {
+   module_type: RootOutput
+   dataTier: "reconstructed"
+   compressionLevel: 1
+   saveMemoryObjectThreshold: 0
+   fileName:    "%ifb_mc3.root" #default file name, can override from command line with -o or --output
+   outputCommands: ["keep *_*_*_*", "drop *_*_*_DLDeployMC3"]
+   #outputCommands: ["keep *_*_*_*"]
+ }
+}
+
+# Configuration for TFileMetadataMicroBooNE service
+microboone_tfile_metadata:
+{
+  JSONFileName: [ "merged_dlreco.root.json" ]
+  GenerateTFileMetadata: [ true ]
+  dataTier:              [ "merged_dlreco" ]
+  fileFormat:            [ "root" ]
+}
+
+# Turn on Mask-RCNN
+#physics.producers.ubdl.CosmicMRCNNMode: "PyTorchCPU"
+
+# configure reco producers:
+physics.producers.saturation.HGProducer: "mixer"
+physics.producers.saturation.LGProducer: "mixer"
+physics.producers.wcopflash.OpDataProducerBeam: "mixer"
+physics.filters.crtveto: @local::UBCRTCosmicFilterBNBOFF
+physics.producers.crthitcorrFirstPass.IsOverlay: true
+physics.producers.crthitcorr.CrtHitsIn_Label1: "crthitcorrFirstPass"
+
+# configure larlite
+# -- trigger --
+# MC
+physics.analyzers.opreco.DataLookUpMap.trigger: ["triggersim"]
+# -- CRT --
+physics.analyzers.opreco.DataLookUpMap.crthit:   ["crthitcorr"]
+physics.analyzers.opreco.DataLookUpMap.crttrack: ["crttrack"]
+physics.analyzers.opreco.DataLookUpMap.daqheadertimeuboone: ["daq"]
+physics.analyzers.opreco.DAQHeaderProducer: "daq"
+physics.analyzers.opreco.DAQHeaderTimeUBProducer: "daq"
+
+physics.analyzers.opreco.DataLookUpMap.opflash: ["simpleFlashBeam","simpleFlashCosmic","wcopflash:beam","wcopflash:cosmic"]
+physics.analyzers.opreco.DataLookUpMap.opdigit: ["wcopflash:MergedBeam","wcopflash:MergedCosmic"]
+physics.analyzers.opreco.DataLookUpMap.ophit: []
+physics.analyzers.opreco.AssociationLookUpMap.ophit: []
+physics.analyzers.opreco.AssociationLookUpMap.opflash: []
+physics.analyzers.mcinfo.DataLookUpMap.mceventweight: []
+#physics.analyzers.opreco.DataLookUpMap.ophit: ["ophitBeamNoRemap::DLDeploy","ophitBeam::DLDeploy","ophitBeamCalib::DLDeploy","ophitCosmicCalib::DLDeploy"]
+
+# configure truth supera
+#physics.analyzers.superaMCTruth.supera_params: "supera_mctruth_no_wcthrumu.fcl" # for no-WC debug only

--- a/ubcv/LArCVImageMaker/mcc10_prod_scripts/mcc10_dlreco_w_wirecell_driver_overlay_lantern_set4.fcl
+++ b/ubcv/LArCVImageMaker/mcc10_prod_scripts/mcc10_dlreco_w_wirecell_driver_overlay_lantern_set4.fcl
@@ -1,0 +1,171 @@
+#include "dlprod_fclbase_producers.fcl"
+#include "dlprod_fclbase_analyzers_gen2.fcl"
+#include "time_memory_tracker_microboone.fcl"
+#include "reco_uboone_data_mcc9_10.fcl"
+
+## To see example workflow context for this driver see: 
+## https://cdcvs.fnal.gov/redmine/projects/uboone-physics-analysis/wiki/MCC10_Release_Page#Data-Beam-On-NuMI
+
+BEGIN_PROLOG
+
+litedata_wctagger: @local::litemaker_base
+litedata_wctagger.out_filename: "larlite_wctagger.root"
+litedata_wctagger.DataLookUpMap:
+{
+  sps : [ "portedSpacePointsThreshold" ]
+  hit : [ "portedThresholdhit" ]
+}
+
+END_PROLOG
+
+
+process_name: DLDeployMC4
+
+services:
+{
+  TFileService: { fileName: "larcv_hist.root" }  
+  scheduler:    { defaultExceptions: false }
+  #TimeTracker:             @local::microboone_time_tracker
+  MemoryTracker:           @local::microboone_memory_tracker
+  RandomNumberGenerator:   {} #ART native random number generator
+  message:                 @local::microboone_message_services_prod_debug
+  FileCatalogMetadata:     @local::art_file_catalog_data
+  @table::microboone_services_reco
+}
+
+#services.TimeTracker.printSummary: false
+#services.TimeTracker.dbOutput: {}
+#services.MemoryTracker.printSummaries: []
+#services.MemoryTracker.includeMallocInfo: false
+
+services.DetectorClocksService.TrigModuleName: "daq"  # note that the clock time needed for the flash timing proper reconstruction
+services.DetectorPropertiesService.NumberTimeSamples:        6400
+services.DetectorPropertiesService.ReadOutWindowSize:        6400
+services.DetectorClocksService.InheritClockConfig:           false
+services.DetectorClocksService.TriggerOffsetTPC:             -0.400e3
+services.FileCatalogMetadata.fileType: "overlay"
+services.SpaceCharge.EnableSimSpatialSCE: true
+services.SpaceCharge.EnableSimEfieldSCE:  true
+services.LLMetaMaker: {Enable: false}
+services.LArCVMetaMaker: {Enable: false}
+
+source:
+{
+  module_type: RootInput
+  maxEvents:   -1        # Number of events to read
+}
+
+source_gen:
+{
+  module_type: EmptyEvent
+  timestampPlugin: { plugin_type: "GeneratedEventTimestamp" }
+  maxEvents:   10          # Number of events to create
+  firstRun:    1        # Run number to use for this file
+  firstEvent:  1           # number of first event in the file
+}
+
+source_reprocess:
+{
+  module_type: RootInput
+  maxEvents:   100000     # Number of events to create
+}
+
+
+# drop past optical products
+source.inputCommands: ["keep *_*_*_*"]
+#                       "drop *_*_*_Data*RecoStage2", 
+#                       "drop *_*_*_MC*RecoStage2"]
+
+physics:
+{
+ producers: {
+   @table::dlprod_producers
+   @table::microboone_reco_data_producers
+   #ubdl: @local::microboone_ubdl
+ }
+
+ filters: {
+   @table::microboone_reco_data_filters
+ }
+
+ analyzers: {
+   @table::dlprod_analyzers
+   wctagger: @local::litedata_wctagger
+ }
+
+ reco: [ @sequence::microboone_reco_data_optical, 
+         "wcopflash",
+         "rns", 
+         "crtt0Correction",
+         "crthitcorrFirstPass",
+         "crthitcorr",
+         "crttzero",
+         "crttrack"]
+         #"opfiltercommonext" ]
+ #trigger_paths: [reco]
+
+
+ #dlnetpath: [ubdl]
+ #stream: [opreco, reco2d, mcinfo, gaushitMCinfoBacktracker, wctagger, superaMCTruthOnly, out1]
+ #stream: [opreco, mcinfo, wctagger, superaMCTruth]
+ #stream: [opreco, mcinfo, superaMCTruth, out1]
+ stream: [superaMCTruth4, out1]
+ end_paths: [stream]
+ #trigger_paths: [ dlnetpath ]
+}
+
+outputs:
+{
+ out1:
+ {
+   module_type: RootOutput
+   dataTier: "reconstructed"
+   compressionLevel: 1
+   saveMemoryObjectThreshold: 0
+   fileName:    "%ifb_mc4.root" #default file name, can override from command line with -o or --output
+   outputCommands: ["keep *_*_*_*", "drop *_*_*_DLDeployMC4"]
+   #outputCommands: ["keep *_*_*_*"]
+ }
+}
+
+# Configuration for TFileMetadataMicroBooNE service
+microboone_tfile_metadata:
+{
+  JSONFileName: [ "merged_dlreco.root.json" ]
+  GenerateTFileMetadata: [ true ]
+  dataTier:              [ "merged_dlreco" ]
+  fileFormat:            [ "root" ]
+}
+
+# Turn on Mask-RCNN
+#physics.producers.ubdl.CosmicMRCNNMode: "PyTorchCPU"
+
+# configure reco producers:
+physics.producers.saturation.HGProducer: "mixer"
+physics.producers.saturation.LGProducer: "mixer"
+physics.producers.wcopflash.OpDataProducerBeam: "mixer"
+physics.filters.crtveto: @local::UBCRTCosmicFilterBNBOFF
+physics.producers.crthitcorrFirstPass.IsOverlay: true
+physics.producers.crthitcorr.CrtHitsIn_Label1: "crthitcorrFirstPass"
+
+# configure larlite
+# -- trigger --
+# MC
+physics.analyzers.opreco.DataLookUpMap.trigger: ["triggersim"]
+# -- CRT --
+physics.analyzers.opreco.DataLookUpMap.crthit:   ["crthitcorr"]
+physics.analyzers.opreco.DataLookUpMap.crttrack: ["crttrack"]
+physics.analyzers.opreco.DataLookUpMap.daqheadertimeuboone: ["daq"]
+physics.analyzers.opreco.DAQHeaderProducer: "daq"
+physics.analyzers.opreco.DAQHeaderTimeUBProducer: "daq"
+
+physics.analyzers.opreco.DataLookUpMap.opflash: ["simpleFlashBeam","simpleFlashCosmic","wcopflash:beam","wcopflash:cosmic"]
+physics.analyzers.opreco.DataLookUpMap.opdigit: ["wcopflash:MergedBeam","wcopflash:MergedCosmic"]
+physics.analyzers.opreco.DataLookUpMap.ophit: []
+physics.analyzers.opreco.AssociationLookUpMap.ophit: []
+physics.analyzers.opreco.AssociationLookUpMap.opflash: []
+physics.analyzers.mcinfo.DataLookUpMap.mceventweight: []
+#physics.analyzers.opreco.DataLookUpMap.ophit: ["ophitBeamNoRemap::DLDeploy","ophitBeam::DLDeploy","ophitBeamCalib::DLDeploy","ophitCosmicCalib::DLDeploy"]
+
+# configure truth supera
+#physics.analyzers.superaMCTruth.supera_params: "supera_mctruth_no_wcthrumu.fcl" # for no-WC debug only

--- a/ubcv/LArCVImageMaker/mcc10_prod_scripts/mcc10_dlreco_w_wirecell_driver_overlay_lantern_set5.fcl
+++ b/ubcv/LArCVImageMaker/mcc10_prod_scripts/mcc10_dlreco_w_wirecell_driver_overlay_lantern_set5.fcl
@@ -1,0 +1,171 @@
+#include "dlprod_fclbase_producers.fcl"
+#include "dlprod_fclbase_analyzers_gen2.fcl"
+#include "time_memory_tracker_microboone.fcl"
+#include "reco_uboone_data_mcc9_10.fcl"
+
+## To see example workflow context for this driver see: 
+## https://cdcvs.fnal.gov/redmine/projects/uboone-physics-analysis/wiki/MCC10_Release_Page#Data-Beam-On-NuMI
+
+BEGIN_PROLOG
+
+litedata_wctagger: @local::litemaker_base
+litedata_wctagger.out_filename: "larlite_wctagger.root"
+litedata_wctagger.DataLookUpMap:
+{
+  sps : [ "portedSpacePointsThreshold" ]
+  hit : [ "portedThresholdhit" ]
+}
+
+END_PROLOG
+
+
+process_name: DLDeployMC5
+
+services:
+{
+  TFileService: { fileName: "larcv_hist.root" }  
+  scheduler:    { defaultExceptions: false }
+  #TimeTracker:             @local::microboone_time_tracker
+  MemoryTracker:           @local::microboone_memory_tracker
+  RandomNumberGenerator:   {} #ART native random number generator
+  message:                 @local::microboone_message_services_prod_debug
+  FileCatalogMetadata:     @local::art_file_catalog_data
+  @table::microboone_services_reco
+}
+
+#services.TimeTracker.printSummary: false
+#services.TimeTracker.dbOutput: {}
+#services.MemoryTracker.printSummaries: []
+#services.MemoryTracker.includeMallocInfo: false
+
+services.DetectorClocksService.TrigModuleName: "daq"  # note that the clock time needed for the flash timing proper reconstruction
+services.DetectorPropertiesService.NumberTimeSamples:        6400
+services.DetectorPropertiesService.ReadOutWindowSize:        6400
+services.DetectorClocksService.InheritClockConfig:           false
+services.DetectorClocksService.TriggerOffsetTPC:             -0.400e3
+services.FileCatalogMetadata.fileType: "overlay"
+services.SpaceCharge.EnableSimSpatialSCE: true
+services.SpaceCharge.EnableSimEfieldSCE:  true
+services.LLMetaMaker: {Enable: false}
+services.LArCVMetaMaker: {Enable: false}
+
+source:
+{
+  module_type: RootInput
+  maxEvents:   -1        # Number of events to read
+}
+
+source_gen:
+{
+  module_type: EmptyEvent
+  timestampPlugin: { plugin_type: "GeneratedEventTimestamp" }
+  maxEvents:   10          # Number of events to create
+  firstRun:    1        # Run number to use for this file
+  firstEvent:  1           # number of first event in the file
+}
+
+source_reprocess:
+{
+  module_type: RootInput
+  maxEvents:   100000     # Number of events to create
+}
+
+
+# drop past optical products
+source.inputCommands: ["keep *_*_*_*"]
+#                       "drop *_*_*_Data*RecoStage2", 
+#                       "drop *_*_*_MC*RecoStage2"]
+
+physics:
+{
+ producers: {
+   @table::dlprod_producers
+   @table::microboone_reco_data_producers
+   #ubdl: @local::microboone_ubdl
+ }
+
+ filters: {
+   @table::microboone_reco_data_filters
+ }
+
+ analyzers: {
+   @table::dlprod_analyzers
+   wctagger: @local::litedata_wctagger
+ }
+
+ reco: [ @sequence::microboone_reco_data_optical, 
+         "wcopflash",
+         "rns", 
+         "crtt0Correction",
+         "crthitcorrFirstPass",
+         "crthitcorr",
+         "crttzero",
+         "crttrack"]
+         #"opfiltercommonext" ]
+ #trigger_paths: [reco]
+
+
+ #dlnetpath: [ubdl]
+ #stream: [opreco, reco2d, mcinfo, gaushitMCinfoBacktracker, wctagger, superaMCTruthOnly, out1]
+ #stream: [opreco, mcinfo, wctagger, superaMCTruth]
+ #stream: [opreco, mcinfo, superaMCTruth, out1]
+ stream: [superaMCTruth5, out1]
+ end_paths: [stream]
+ #trigger_paths: [ dlnetpath ]
+}
+
+outputs:
+{
+ out1:
+ {
+   module_type: RootOutput
+   dataTier: "reconstructed"
+   compressionLevel: 1
+   saveMemoryObjectThreshold: 0
+   fileName:    "%ifb_mc5.root" #default file name, can override from command line with -o or --output
+   outputCommands: ["keep *_*_*_*", "drop *_*_*_DLDeployMC5"]
+   #outputCommands: ["keep *_*_*_*"]
+ }
+}
+
+# Configuration for TFileMetadataMicroBooNE service
+microboone_tfile_metadata:
+{
+  JSONFileName: [ "merged_dlreco.root.json" ]
+  GenerateTFileMetadata: [ true ]
+  dataTier:              [ "merged_dlreco" ]
+  fileFormat:            [ "root" ]
+}
+
+# Turn on Mask-RCNN
+#physics.producers.ubdl.CosmicMRCNNMode: "PyTorchCPU"
+
+# configure reco producers:
+physics.producers.saturation.HGProducer: "mixer"
+physics.producers.saturation.LGProducer: "mixer"
+physics.producers.wcopflash.OpDataProducerBeam: "mixer"
+physics.filters.crtveto: @local::UBCRTCosmicFilterBNBOFF
+physics.producers.crthitcorrFirstPass.IsOverlay: true
+physics.producers.crthitcorr.CrtHitsIn_Label1: "crthitcorrFirstPass"
+
+# configure larlite
+# -- trigger --
+# MC
+physics.analyzers.opreco.DataLookUpMap.trigger: ["triggersim"]
+# -- CRT --
+physics.analyzers.opreco.DataLookUpMap.crthit:   ["crthitcorr"]
+physics.analyzers.opreco.DataLookUpMap.crttrack: ["crttrack"]
+physics.analyzers.opreco.DataLookUpMap.daqheadertimeuboone: ["daq"]
+physics.analyzers.opreco.DAQHeaderProducer: "daq"
+physics.analyzers.opreco.DAQHeaderTimeUBProducer: "daq"
+
+physics.analyzers.opreco.DataLookUpMap.opflash: ["simpleFlashBeam","simpleFlashCosmic","wcopflash:beam","wcopflash:cosmic"]
+physics.analyzers.opreco.DataLookUpMap.opdigit: ["wcopflash:MergedBeam","wcopflash:MergedCosmic"]
+physics.analyzers.opreco.DataLookUpMap.ophit: []
+physics.analyzers.opreco.AssociationLookUpMap.ophit: []
+physics.analyzers.opreco.AssociationLookUpMap.opflash: []
+physics.analyzers.mcinfo.DataLookUpMap.mceventweight: []
+#physics.analyzers.opreco.DataLookUpMap.ophit: ["ophitBeamNoRemap::DLDeploy","ophitBeam::DLDeploy","ophitBeamCalib::DLDeploy","ophitCosmicCalib::DLDeploy"]
+
+# configure truth supera
+#physics.analyzers.superaMCTruth.supera_params: "supera_mctruth_no_wcthrumu.fcl" # for no-WC debug only

--- a/ubcv/LArCVImageMaker/mcc10_prod_scripts/merge_dlreco_fnal_overlay_and_mc_lantern_multiStage.sh
+++ b/ubcv/LArCVImageMaker/mcc10_prod_scripts/merge_dlreco_fnal_overlay_and_mc_lantern_multiStage.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+# To be run after the output of
+# - for overlay: mcc10_dlreco_w_wirecell_driver_overlay_lantern.fcl
+# - for mc: mcc10_dlreco_w_wirecell_driver_mc_lantern.fcl
+
+echo "<< FILES available >> "
+ls -lh *.root
+
+# (lantern dlreco)
+#ubdlout=`ls -1 *_ubdl.root | tail -n 1`
+#echo "COPY OUTPUT OF DLMERGED STAGE TO SCRATCH"
+#ifdh cp -D Physics*_ubdl.root /pnfs/uboone/scratch/users/tmw/v10_04_07_05/intermediate_outputs/
+
+# OUTPUT FILES FROM PREVIOUS STAGE:
+#larcv.root
+#larlite_opreco.root
+#larlite_mcinfo.root
+
+# opreco contents
+#TFile**larlite_opreco.root
+#TFile*larlite_opreco.root
+#KEY: TTree larlite_id_tree;1LArLite Event ID Tree
+#KEY: TTree daqheadertimeuboone_daq_tree;1daqheadertimeuboone Tree by daq
+# KEY: TTree crthit_crthitcorr_tree;1crthit Tree by crthitcorr
+# KEY: TTree crttrack_crttrack_tree;1crttrack Tree by crttrack
+# KEY: TTree ophit_ophitBeam::DLDeploy_tree;1ophit Tree by ophitBeam::DLDeploy
+# KEY: TTree ophit_ophitBeamCalib::DLDeploy_tree;1ophit Tree by ophitBeamCalib::DLDeploy
+# KEY: TTree ophit_ophitBeamNoRemap::DLDeploy_tree;1ophit Tree by ophitBeamNoRemap::DLDeploy
+# KEY: TTree ophit_ophitCosmicCalib::DLDeploy_tree;1ophit Tree by ophitCosmicCalib::DLDeploy
+# KEY: TTree opflash_simpleFlashBeam_tree;1opflash Tree by simpleFlashBeam
+# KEY: TTree opflash_simpleFlashBeamLowPE_tree;1opflash Tree by simpleFlashBeamLowPE
+# KEY: TTree opflash_simpleFlashCosmic_tree;1opflash Tree by simpleFlashCosmic
+# KEY: TTree opflash_wcopflash:beam:DLDeploy_tree;1opflash Tree by wcopflash:beam:DLDeploy
+# KEY: TTree opflash_wcopflash:cosmic:DLDeploy_tree;1opflash Tree by wcopflash:cosmic:DLDeploy
+# KEY: TTree trigger_triggersim_tree;1trigger Tree by triggersim
+# KEY: TTree ass_simpleFlashBeam_tree;1ass Tree by simpleFlashBeam
+# KEY: TTree ass_simpleFlashBeamLowPE_tree;1ass Tree by simpleFlashBeamLowPE
+# KEY: TTree ass_simpleFlashCosmic_tree;1ass Tree by simpleFlashCosmic
+# KEY: TTree ass_wcopflash:beam:DLDeploy_tree;1ass Tree by wcopflash:beam:DLDeploy
+# KEY: TTree ass_wcopflash:cosmic:DLDeploy_tree;1ass Tree by wcopflash:cosmic:DLDeploy
+# KEY: TTree opdigit_wcopflash:MergedBeam:DLDeploy_tree;1opdigit Tree by wcopflash:MergedBeam:DLDeploy
+# KEY: TTree opdigit_wcopflash:MergedCosmic:DLDeploy_tree;1opdigit Tree by wcopflash:MergedCosmic:DLDeploy
+# KEY: TTree swtrigger_swtrigger_tree;1swtrigger Tree by swtrigger
+
+# larcv objects: "chstatus_wire_tree", "image2d_ancestor_tree", "image2d_instance_tree", "image2d_larflow_tree", "image2d_segment_tree", "image2d_thrumu_tree", "image2d_wire_tree", "partroi_segment_tree"
+rm -f extract_opreco.root
+rm -f extract_larcv.root
+
+# We want to rename complicated names
+shopt -s expand_aliases
+xrootcp=`which rootcp` # have to do this because of broken env call at top of rootcp
+python3 ${xrootcp} larlite_opreco.root:daqheadertimeuboone_daq_tree            extract_opreco.root
+python3 ${xrootcp} larlite_opreco.root:swtrigger_swtrigger_tree                extract_opreco.root
+python3 ${xrootcp} larlite_opreco.root:trigger_triggersim_tree                 extract_opreco.root
+python3 ${xrootcp} larlite_opreco.root:crthit_crthitcorr_tree                  extract_opreco.root
+python3 ${xrootcp} larlite_opreco.root:crttrack_crttrack_tree                  extract_opreco.root
+#python3 ${xrootcp} larlite_opreco.root:opflash_simpleFlashBeam_tree   extract_opreco.root:opflash_simpleFlashBeam_tree
+#python3 ${xrootcp} larlite_opreco.root:opflash_simpleFlashCosmic_tree extract_opreco.root:opflash_simpleFlashCosmic_tree
+#python3 ${xrootcp} larlite_opreco.root:opflash_wcopflash*beam_tree    extract_opreco.root:opflash_wcopflashbeam_tree
+#python3 ${xrootcp} larlite_opreco.root:opflash_wcopflash*cosmic_tree  extract_opreco.root:opflash_wcopflashcosmic_tree
+#python3 ${xrootcp} larlite_opreco.root:opdigit_wcopflash*MergedBeam_tree   extract_opreco.root:opdigit_wcopflashbeam_tree
+#python3 ${xrootcp} larlite_opreco.root:opdigit_wcopflash*MergedCosmic_tree extract_opreco.root:opdigit_wcopflashcosmic_tree
+python3 ${xrootcp} larlite_opreco.root:opflash_*_tree   extract_opreco.root
+python3 ${xrootcp} larlite_opreco.root:opdigit_*_tree   extract_opreco.root
+
+# extract particular larcv tres
+# KEY: TTreechstatus_wire_tree;1wire tree
+# KEY: TTreeimage2d_ancestor_tree;1ancestor tree
+# KEY: TTreeimage2d_instance_tree;1instance tree
+# KEY: TTreeimage2d_larflow_tree;1larflow tree
+# KEY: TTreeimage2d_segment_tree;1segment tree
+# KEY: TTreeimage2d_thrumu_tree;1thrumu tree
+# KEY: TTreeimage2d_wire_tree;1wire tree
+# KEY: TTreepartroi_segment_tree;1segment tree
+
+python3 ${xrootcp} larcv.root:image2d_wire_tree       extract_larcv.root
+python3 ${xrootcp} larcv.root:image2d_thrumu_tree     extract_larcv.root
+python3 ${xrootcp} larcv.root:chstatus_wire_tree      extract_larcv.root
+
+python3 ${xrootcp} larcv_mc3.root:image2d_ancestor_tree   extract_larcv.root
+python3 ${xrootcp} larcv_mc3.root:image2d_instance_tree   extract_larcv.root
+python3 ${xrootcp} larcv_mc2.root:image2d_segment_tree    extract_larcv.root
+python3 ${xrootcp} larcv_mc5.root:image2d_larflow_tree    extract_larcv.root
+python3 ${xrootcp} larcv_mc4.root:partroi_segment_tree    extract_larcv.root
+
+hadd merged_dlreco.root larlite_mcinfo.root extract_opreco.root extract_larcv.root
+
+# LARLITE FILES TO MERGE
+# -----------------------
+# LARLITE_FILE_LIST="merged_dlreco.root larlite_opreco.root larlite_mcinfo.root"
+
+# echo "LARLITE FILES: ${LARLITE_FILE_LIST}"
+# echo ""
+
+# echo "<< combine larlite files >>"
+# python $UBDL_BASEDIR/fnal_prod/combine_larlite.py -o $LARLITE_FILE_LIST
+# echo "<<< Append UBDL Products >>>"
+# python $UBDL_BASEDIR/fnal_prod/append_supera_products_mc.py merged_dlreco.root larcv.root
+
+echo "<<< cleanup excess root files >>>"
+CMD="rm -f larlite_opreco.root larlite_mcinfo.root larcv.root larcv_mc2.root larcv_mc3.root larcv_mc4.root larcv_mc5.root larcv_hist.root extract_opreco.root extract_larcv.root"
+echo $CMD
+$CMD

--- a/ubcv/LArCVImageMaker/mcc10_prod_scripts/supera_mctruth_set2.fcl
+++ b/ubcv/LArCVImageMaker/mcc10_prod_scripts/supera_mctruth_set2.fcl
@@ -1,0 +1,126 @@
+ProcessDriver: {
+
+  Verbosity:    1
+  EnableFilter: false
+  RandomAccess: false
+  ProcessType:  ["SuperaMetaMaker","SuperaSimCh"]
+  ProcessName:  ["SuperaMetaMaker","SuperaSimCh"]
+
+  IOManager: {
+    Verbosity: 2
+    Name:        "IOManager"
+    IOMode:      1
+    OutFileName: "out_test.root"
+    InputFiles:  []
+    InputDirs:   []
+    StoreOnlyType: []
+    StoreOnlyName: []
+  }
+
+  ProcessList: {
+    SuperaMetaMaker: {
+      Verbosity: 1
+      MetaConfig: {
+        MinTime:          2400
+        MinWire:          0
+        EventImageRows:   [1008,1008,1008]
+        EventImageCols:   [3456,3456,3456]
+        EventCompRows:    [6,6,6]
+        EventCompCols:    [1,1,1]
+      }
+    }
+    WireMask: {
+      Verbosity: 2
+      ChStatusProducer: "wiremc"
+      ImageProducer:    "wiremc"
+    }
+    SuperaSimCh: {
+      Verbosity: 2
+      OutImageLabel:       "segment"
+      OutROILabel:         "segment"
+      LArMCTruthProducer:  "generator"
+      LArMCTrackProducer:  "mcreco"
+      LArMCShowerProducer: "mcreco"
+      LArSimChProducer:    "driftWC simpleSC"
+      Origin: 1
+      TimeOffset: 2400
+    }
+    SuperaInstanceImage: {
+      Verbosity: 0
+      OutImageLabel:        "instance"
+      AncestorImageLabel:   "ancestor"
+      OutROILabel:          "segment"
+      LArMCTruthProducer:   "generator"
+      LArMCTrackProducer:   "mcreco"
+      LArMCShowerProducer:  "mcreco"
+      LArSimChProducer:     "driftWC simpleSC"
+      ChStatusProducer:     "wiremc"
+      Origin: 0
+      TimeOffset: 2400
+    }
+    SuperaMCROI: {
+      Verbosity: 2
+      OutROILabel:         "segment"
+      LArMCTruthProducer:  "generator"
+      LArMCTrackProducer:  "mcreco"
+      LArMCShowerProducer: "mcreco"
+      LArSimChProducer:    "driftWC simpleSC"
+      TimeOffset: 2400
+      Origin: 0
+      StoreG4SecondaryROI:  false
+      StoreG4PrimaryROI:    true
+      FilterTargetPDG:      []
+      FilterTargetInitEMin: []
+      FilterTargetDepEMin:  []
+      ShowerInitEMin: 0
+      ShowerDepEMin:  20
+      TrackInitEMin:  0
+      TrackDepEMin:   20
+      FilterROIMinRows: 0
+      FilterROIMinCols: 0
+      MCParticleTree: {
+        Verbosity:    2
+        UseG4Primary: false
+	DTMax:        10000
+      }
+      MCROIMaker: {
+        Verbosity:    2
+   	MaxTimeTick:  8448
+        TimePadding:  10
+        WirePadding:  10
+        MinWidth:     2
+        MinHeight:    2
+	ApplySCE:     true
+      }
+    }
+    SuperaWire: {
+      Verbosity: 2
+      OutImageLabel:    "wire"
+      LArWireProducer:  "butcher"
+      TimeOffset: 2400
+    }
+    SuperaChStatus: {
+      Verbosity: 2
+      LArChStatusProducer: "chstatus"
+      OutChStatusLabel:    "wire"
+    }
+    SuperaLArFlow: {
+      Verbosity: 0
+      OutImageLabel:       "larflow"
+      LArMCTruthProducer:  "generator"
+      LArMCTrackProducer:  "mcreco"
+      LArMCShowerProducer: "mcreco"
+      WireProducer:        "wiremc"
+      ChStatusProducer:    "wiremc"
+      LArSimChProducer:    "driftWC simpleSC"
+      EdepAtAnode: true
+    }
+    SuperaWCThrumuImage: {
+      Verbosity: 0
+      LArHitProducer: "portedThresholdhit"
+      InputWireTreeName: "wire"
+      OutImageLabel: "thrumu"
+    }
+  }
+}
+

--- a/ubcv/LArCVImageMaker/mcc10_prod_scripts/supera_mctruth_set3.fcl
+++ b/ubcv/LArCVImageMaker/mcc10_prod_scripts/supera_mctruth_set3.fcl
@@ -1,0 +1,126 @@
+ProcessDriver: {
+
+  Verbosity:    1
+  EnableFilter: false
+  RandomAccess: false
+  ProcessType:  ["SuperaMetaMaker","SuperaInstanceImage"]
+  ProcessName:  ["SuperaMetaMaker","SuperaInstanceImage"]
+
+  IOManager: {
+    Verbosity: 2
+    Name:        "IOManager"
+    IOMode:      1
+    OutFileName: "out_test.root"
+    InputFiles:  []
+    InputDirs:   []
+    StoreOnlyType: []
+    StoreOnlyName: []
+  }
+
+  ProcessList: {
+    SuperaMetaMaker: {
+      Verbosity: 1
+      MetaConfig: {
+        MinTime:          2400
+        MinWire:          0
+        EventImageRows:   [1008,1008,1008]
+        EventImageCols:   [3456,3456,3456]
+        EventCompRows:    [6,6,6]
+        EventCompCols:    [1,1,1]
+      }
+    }
+    WireMask: {
+      Verbosity: 2
+      ChStatusProducer: "wiremc"
+      ImageProducer:    "wiremc"
+    }
+    SuperaSimCh: {
+      Verbosity: 2
+      OutImageLabel:       "segment"
+      OutROILabel:         "segment"
+      LArMCTruthProducer:  "generator"
+      LArMCTrackProducer:  "mcreco"
+      LArMCShowerProducer: "mcreco"
+      LArSimChProducer:    "driftWC simpleSC"
+      Origin: 1
+      TimeOffset: 2400
+    }
+    SuperaInstanceImage: {
+      Verbosity: 0
+      OutImageLabel:        "instance"
+      AncestorImageLabel:   "ancestor"
+      OutROILabel:          "segment"
+      LArMCTruthProducer:   "generator"
+      LArMCTrackProducer:   "mcreco"
+      LArMCShowerProducer:  "mcreco"
+      LArSimChProducer:     "driftWC simpleSC"
+      ChStatusProducer:     "wiremc"
+      Origin: 0
+      TimeOffset: 2400
+    }
+    SuperaMCROI: {
+      Verbosity: 2
+      OutROILabel:         "segment"
+      LArMCTruthProducer:  "generator"
+      LArMCTrackProducer:  "mcreco"
+      LArMCShowerProducer: "mcreco"
+      LArSimChProducer:    "driftWC simpleSC"
+      TimeOffset: 2400
+      Origin: 0
+      StoreG4SecondaryROI:  false
+      StoreG4PrimaryROI:    true
+      FilterTargetPDG:      []
+      FilterTargetInitEMin: []
+      FilterTargetDepEMin:  []
+      ShowerInitEMin: 0
+      ShowerDepEMin:  20
+      TrackInitEMin:  0
+      TrackDepEMin:   20
+      FilterROIMinRows: 0
+      FilterROIMinCols: 0
+      MCParticleTree: {
+        Verbosity:    2
+        UseG4Primary: false
+	DTMax:        10000
+      }
+      MCROIMaker: {
+        Verbosity:    2
+   	MaxTimeTick:  8448
+        TimePadding:  10
+        WirePadding:  10
+        MinWidth:     2
+        MinHeight:    2
+	ApplySCE:     true
+      }
+    }
+    SuperaWire: {
+      Verbosity: 2
+      OutImageLabel:    "wire"
+      LArWireProducer:  "butcher"
+      TimeOffset: 2400
+    }
+    SuperaChStatus: {
+      Verbosity: 2
+      LArChStatusProducer: "chstatus"
+      OutChStatusLabel:    "wire"
+    }
+    SuperaLArFlow: {
+      Verbosity: 0
+      OutImageLabel:       "larflow"
+      LArMCTruthProducer:  "generator"
+      LArMCTrackProducer:  "mcreco"
+      LArMCShowerProducer: "mcreco"
+      WireProducer:        "wiremc"
+      ChStatusProducer:    "wiremc"
+      LArSimChProducer:    "driftWC simpleSC"
+      EdepAtAnode: true
+    }
+    SuperaWCThrumuImage: {
+      Verbosity: 0
+      LArHitProducer: "portedThresholdhit"
+      InputWireTreeName: "wire"
+      OutImageLabel: "thrumu"
+    }
+  }
+}
+

--- a/ubcv/LArCVImageMaker/mcc10_prod_scripts/supera_mctruth_set4.fcl
+++ b/ubcv/LArCVImageMaker/mcc10_prod_scripts/supera_mctruth_set4.fcl
@@ -1,0 +1,126 @@
+ProcessDriver: {
+
+  Verbosity:    1
+  EnableFilter: false
+  RandomAccess: false
+  ProcessType:  ["SuperaMetaMaker","SuperaMCROI"]
+  ProcessName:  ["SuperaMetaMaker","SuperaMCROI"]
+
+  IOManager: {
+    Verbosity: 2
+    Name:        "IOManager"
+    IOMode:      1
+    OutFileName: "out_test.root"
+    InputFiles:  []
+    InputDirs:   []
+    StoreOnlyType: []
+    StoreOnlyName: []
+  }
+
+  ProcessList: {
+    SuperaMetaMaker: {
+      Verbosity: 1
+      MetaConfig: {
+        MinTime:          2400
+        MinWire:          0
+        EventImageRows:   [1008,1008,1008]
+        EventImageCols:   [3456,3456,3456]
+        EventCompRows:    [6,6,6]
+        EventCompCols:    [1,1,1]
+      }
+    }
+    WireMask: {
+      Verbosity: 2
+      ChStatusProducer: "wiremc"
+      ImageProducer:    "wiremc"
+    }
+    SuperaSimCh: {
+      Verbosity: 2
+      OutImageLabel:       "segment"
+      OutROILabel:         "segment"
+      LArMCTruthProducer:  "generator"
+      LArMCTrackProducer:  "mcreco"
+      LArMCShowerProducer: "mcreco"
+      LArSimChProducer:    "driftWC simpleSC"
+      Origin: 1
+      TimeOffset: 2400
+    }
+    SuperaInstanceImage: {
+      Verbosity: 0
+      OutImageLabel:        "instance"
+      AncestorImageLabel:   "ancestor"
+      OutROILabel:          "segment"
+      LArMCTruthProducer:   "generator"
+      LArMCTrackProducer:   "mcreco"
+      LArMCShowerProducer:  "mcreco"
+      LArSimChProducer:     "driftWC simpleSC"
+      ChStatusProducer:     "wiremc"
+      Origin: 0
+      TimeOffset: 2400
+    }
+    SuperaMCROI: {
+      Verbosity: 2
+      OutROILabel:         "segment"
+      LArMCTruthProducer:  "generator"
+      LArMCTrackProducer:  "mcreco"
+      LArMCShowerProducer: "mcreco"
+      LArSimChProducer:    "driftWC simpleSC"
+      TimeOffset: 2400
+      Origin: 0
+      StoreG4SecondaryROI:  false
+      StoreG4PrimaryROI:    true
+      FilterTargetPDG:      []
+      FilterTargetInitEMin: []
+      FilterTargetDepEMin:  []
+      ShowerInitEMin: 0
+      ShowerDepEMin:  20
+      TrackInitEMin:  0
+      TrackDepEMin:   20
+      FilterROIMinRows: 0
+      FilterROIMinCols: 0
+      MCParticleTree: {
+        Verbosity:    2
+        UseG4Primary: false
+	DTMax:        10000
+      }
+      MCROIMaker: {
+        Verbosity:    2
+   	MaxTimeTick:  8448
+        TimePadding:  10
+        WirePadding:  10
+        MinWidth:     2
+        MinHeight:    2
+	ApplySCE:     true
+      }
+    }
+    SuperaWire: {
+      Verbosity: 2
+      OutImageLabel:    "wire"
+      LArWireProducer:  "butcher"
+      TimeOffset: 2400
+    }
+    SuperaChStatus: {
+      Verbosity: 2
+      LArChStatusProducer: "chstatus"
+      OutChStatusLabel:    "wire"
+    }
+    SuperaLArFlow: {
+      Verbosity: 0
+      OutImageLabel:       "larflow"
+      LArMCTruthProducer:  "generator"
+      LArMCTrackProducer:  "mcreco"
+      LArMCShowerProducer: "mcreco"
+      WireProducer:        "wiremc"
+      ChStatusProducer:    "wiremc"
+      LArSimChProducer:    "driftWC simpleSC"
+      EdepAtAnode: true
+    }
+    SuperaWCThrumuImage: {
+      Verbosity: 0
+      LArHitProducer: "portedThresholdhit"
+      InputWireTreeName: "wire"
+      OutImageLabel: "thrumu"
+    }
+  }
+}
+

--- a/ubcv/LArCVImageMaker/mcc10_prod_scripts/supera_mctruth_set5.fcl
+++ b/ubcv/LArCVImageMaker/mcc10_prod_scripts/supera_mctruth_set5.fcl
@@ -1,0 +1,126 @@
+ProcessDriver: {
+
+  Verbosity:    1
+  EnableFilter: false
+  RandomAccess: false
+  ProcessType:  ["SuperaMetaMaker","SuperaLArFlow"]
+  ProcessName:  ["SuperaMetaMaker","SuperaLArFlow"]
+
+  IOManager: {
+    Verbosity: 2
+    Name:        "IOManager"
+    IOMode:      1
+    OutFileName: "out_test.root"
+    InputFiles:  []
+    InputDirs:   []
+    StoreOnlyType: []
+    StoreOnlyName: []
+  }
+
+  ProcessList: {
+    SuperaMetaMaker: {
+      Verbosity: 1
+      MetaConfig: {
+        MinTime:          2400
+        MinWire:          0
+        EventImageRows:   [1008,1008,1008]
+        EventImageCols:   [3456,3456,3456]
+        EventCompRows:    [6,6,6]
+        EventCompCols:    [1,1,1]
+      }
+    }
+    WireMask: {
+      Verbosity: 2
+      ChStatusProducer: "wiremc"
+      ImageProducer:    "wiremc"
+    }
+    SuperaSimCh: {
+      Verbosity: 2
+      OutImageLabel:       "segment"
+      OutROILabel:         "segment"
+      LArMCTruthProducer:  "generator"
+      LArMCTrackProducer:  "mcreco"
+      LArMCShowerProducer: "mcreco"
+      LArSimChProducer:    "driftWC simpleSC"
+      Origin: 1
+      TimeOffset: 2400
+    }
+    SuperaInstanceImage: {
+      Verbosity: 0
+      OutImageLabel:        "instance"
+      AncestorImageLabel:   "ancestor"
+      OutROILabel:          "segment"
+      LArMCTruthProducer:   "generator"
+      LArMCTrackProducer:   "mcreco"
+      LArMCShowerProducer:  "mcreco"
+      LArSimChProducer:     "driftWC simpleSC"
+      ChStatusProducer:     "wiremc"
+      Origin: 0
+      TimeOffset: 2400
+    }
+    SuperaMCROI: {
+      Verbosity: 2
+      OutROILabel:         "segment"
+      LArMCTruthProducer:  "generator"
+      LArMCTrackProducer:  "mcreco"
+      LArMCShowerProducer: "mcreco"
+      LArSimChProducer:    "driftWC simpleSC"
+      TimeOffset: 2400
+      Origin: 0
+      StoreG4SecondaryROI:  false
+      StoreG4PrimaryROI:    true
+      FilterTargetPDG:      []
+      FilterTargetInitEMin: []
+      FilterTargetDepEMin:  []
+      ShowerInitEMin: 0
+      ShowerDepEMin:  20
+      TrackInitEMin:  0
+      TrackDepEMin:   20
+      FilterROIMinRows: 0
+      FilterROIMinCols: 0
+      MCParticleTree: {
+        Verbosity:    2
+        UseG4Primary: false
+	DTMax:        10000
+      }
+      MCROIMaker: {
+        Verbosity:    2
+   	MaxTimeTick:  8448
+        TimePadding:  10
+        WirePadding:  10
+        MinWidth:     2
+        MinHeight:    2
+	ApplySCE:     true
+      }
+    }
+    SuperaWire: {
+      Verbosity: 2
+      OutImageLabel:    "wire"
+      LArWireProducer:  "butcher"
+      TimeOffset: 2400
+    }
+    SuperaChStatus: {
+      Verbosity: 2
+      LArChStatusProducer: "chstatus"
+      OutChStatusLabel:    "wire"
+    }
+    SuperaLArFlow: {
+      Verbosity: 0
+      OutImageLabel:       "larflow"
+      LArMCTruthProducer:  "generator"
+      LArMCTrackProducer:  "mcreco"
+      LArMCShowerProducer: "mcreco"
+      WireProducer:        "wiremc"
+      ChStatusProducer:    "wiremc"
+      LArSimChProducer:    "driftWC simpleSC"
+      EdepAtAnode: true
+    }
+    SuperaWCThrumuImage: {
+      Verbosity: 0
+      LArHitProducer: "portedThresholdhit"
+      InputWireTreeName: "wire"
+      OutImageLabel: "thrumu"
+    }
+  }
+}
+


### PR DESCRIPTION
This PR does not change any existing code or configurations, it just adds some additional configurations and fcl files, so it can safely be merged. The additions are a new set of fcl files that allow mcc10_dlreco_w_wirecell_driver_overlay_lantern.fcl to be run in 5 separate stages. This update allow the different types of larcv images to be written to file one at a time rather than keeping them all in memory until written to file at the end. This reduces memory requirements for producing larcv images by about 10%.