### PR TITLE
Make sure dlreco always gets metadata

### DIFF
--- a/ubcv/LArCVImageMaker/mcc10_prod_scripts/define_metadata_lantern.fcl
+++ b/ubcv/LArCVImageMaker/mcc10_prod_scripts/define_metadata_lantern.fcl
@@ -37,9 +37,9 @@ outputs:
 # Configuration for TFileMetadataMicroBooNE service
 microboone_tfile_metadata:
 {
-  JSONFileName: [ "larflowreco_kpsrecomanagerana.root.json", "flat_ntuple.root.json" ]
-  GenerateTFileMetadata: [ true, true ]
-  dataTier:              [ "lanternreco", "flat_ntuple" ]
-  fileFormat:            [ "root", "root" ]
+  JSONFileName: [ "larflowreco_kpsrecomanagerana.root.json", "flat_ntuple.root.json" , "merged_dlreco.root.json"]
+  GenerateTFileMetadata: [ true, true, true ]
+  dataTier:              [ "lanternreco", "flat_ntuple", "merged_dlreco" ]
+  fileFormat:            [ "root", "root", "root" ]
 }
 


### PR DESCRIPTION
Modify the fhicl that defines Lantern metadata to also include the dlreco file. This ensure that this file always gets metadata.