### PR TITLE
add script to launch lantern container and run data workflow with alt…

### DIFF
--- a/ubcv/LArCVImageMaker/mcc10_prod_scripts/launch_lantern_container_data_unified_altLArPIDWeights.sh
+++ b/ubcv/LArCVImageMaker/mcc10_prod_scripts/launch_lantern_container_data_unified_altLArPIDWeights.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+echo "executing run script from cvmfs lantern container"
+
+/cvmfs/oasis.opensciencegrid.org/mis/apptainer/1.3.2/bin/apptainer exec --cleanenv $LANTERN_CONTAINER_PATH /cluster/home/lantern_scripts/run_lantern_workflow_data_altLArPIDWeights.sh
+
+echo "Container exited with code $?"
+
+echo "Checking output lantern ntuple"
+
+#make simple root macro to validate lantern ntuple
+cat << 'EOF' > check_lantern.C
+void check_lantern() {
+    TFile *f = TFile::Open("flat_ntuple.root");
+    if (!f || f->IsZombie()) {
+        std::cerr << "lantern ntuple is missing or corrupted" << std::endl;
+        gSystem->Exit(1);
+    }
+    TTree *tree = (TTree*)f->Get("EventTree");
+    if (!tree) {
+        std::cerr << "EventTree not found in lantern ntuple" << std::endl;
+        gSystem->Exit(1);
+    }
+    f->Close();
+    gSystem->Exit(0);
+}
+EOF
+
+#run check lantern macro
+root -l -b -q check_lantern.C
+status=$?
+#clean up
+rm check_lantern.C
+
+#force job crash if lantern ntuple is missing/corrupted
+if [ $status -ne 0 ]; then
+    echo "detected lantern ntuple file error; exiting with code 1"
+    exit 1
+else
+    echo "lantern ntuple file validation passed"
+fi
+
+echo "Merging lantern ntuple into unified ntuple"
+
+unified_ntuple=$(find . -maxdepth 1 -type f -name 'reco_stage_2_hist*.root' -printf '%f\n' -quit)
+
+if [[ -f "$unified_ntuple" && -f "flat_ntuple.root" ]]; then
+    #make simple root macro to merge ntuples
+    cat <<EOF > copy_tree.C
+void copy_tree(const char* sourceFile, const char* destFile) {
+    TFile *source = TFile::Open(sourceFile);
+    TTree *tree = (TTree*)source->Get("EventTree");
+    TFile *target = TFile::Open(destFile, "UPDATE");
+    target->mkdir("lantern");
+    target->cd("lantern");
+    tree->CloneTree()->Write("EventTree");
+    target->Close();
+    source->Close();
+}
+EOF
+    #run merge macro
+    root -l -b -q "copy_tree.C(\"flat_ntuple.root\", \"$unified_ntuple\")"
+    #clean up
+    rm copy_tree.C
+else
+    echo "Could not find ntuple files to merge!!"
+fi
+
+echo "Done!"

--- a/ubcv/LArCVImageMaker/mcc10_prod_scripts/run_lantern_workflow_data.sh
+++ b/ubcv/LArCVImageMaker/mcc10_prod_scripts/run_lantern_workflow_data.sh
@@ -72,7 +72,7 @@ for tree in $inputTrees; do
   rootcp ssnet_ubspurn_output.root:${tree} ${baseinput}
 done
 
-CMD="python3 $LARMATCH_DIR/deploy_larmatchme.py --config-file ${CONFIG_FILE} --supera $baseinput --weights ${LARMATCH_DIR}/${WEIGHT_FILE} --output $lm_outfile --min-score 0.5 --adc-name wire --chstatus-name wire --device-name cpu"
+CMD="python3 $LARMATCH_DIR/deploy_larmatchme.py --config-file ${CONFIG_FILE} --supera $baseinput --weights ${LARMATCH_DIR}/${WEIGHT_FILE} --output $lm_outfile --min-score 0.5 --adc-name wire --chstatus-name wire --device-name cpu --use-skip-limit"
 echo $CMD
 $CMD
 
@@ -80,7 +80,7 @@ CMD="python3 $RECO_TEST_DIR/run_kpsrecoman.py --input-dlmerged ${baseinput} --in
 echo $CMD
 $CMD
 
-CMD="python3 $NTMAKER_DIR/make_dlgen2_flat_ntuples.py -f ${reco_basename}_kpsrecomanagerana.root -t $baseinput -o $ntuple_outfile -m $LARPID_MODEL --ignoreWeights"
+CMD="python3 $NTMAKER_DIR/make_dlgen2_flat_ntuples.py -f ${reco_basename}_kpsrecomanagerana.root -t $baseinput -o $ntuple_outfile -m $LARPID_MODEL --ignoreWeights --noEvtSkipping"
 echo $CMD
 $CMD
 
@@ -89,8 +89,11 @@ CMD="python3 ${NTMAKER_DIR}/extract_and_compress_cosmicreco.py larflowreco_larli
 echo $CMD
 $CMD
 
+echo "extract crt and opflash info from merged_dlreco"
+rootcp merged_dlreco_with_ssnet.root:crthit_*_tree merged_dlreco_with_ssnet.root:crttrack_*_tree merged_dlreco_with_ssnet.root:opflash_*_tree merged_dlreco_with_ssnet.root:opdigit_*_tree extract_from_merged.root
+
 echo "add compressed cosmic tracks to kpsrecomanagerana file"
-hadd larflowreco_kpsrecomanagerana_wcosmic.root compressed_cosmic_components.root larflowreco_kpsrecomanagerana.root
+hadd larflowreco_kpsrecomanagerana_wcosmic.root compressed_cosmic_components.root larflowreco_kpsrecomanagerana.root extract_from_merged.root
 mv larflowreco_kpsrecomanagerana_wcosmic.root larflowreco_kpsrecomanagerana.root
 
 echo "cleaning up intermediate files"
@@ -98,6 +101,7 @@ rm ssnet_output.root ssnet_ubspurn_output.root merged_dlreco_with_ssnet.root
 rm larmatchme_larlite.root larmatchme_larcv.root larflowreco_larlite.root larflowreco_larcv.root
 rm compressed_cosmic_components.root
 rm temp.root
+rm extract_from_merged.root
 
 echo "done!"
 

--- a/ubcv/LArCVImageMaker/mcc10_prod_scripts/run_lantern_workflow_data_altLArPIDWeights.sh
+++ b/ubcv/LArCVImageMaker/mcc10_prod_scripts/run_lantern_workflow_data_altLArPIDWeights.sh
@@ -38,7 +38,7 @@ larsoftout=$(find . -maxdepth 1 -type f -name 'merged_dlreco*.root' -printf '%f\
 baseinput="merged_dlreco_with_ssnet.root"
 CONFIG_FILE="${LANTERN_SCRIPTS}/config_larmatchme_deploycpu.yaml"
 WEIGHT_FILE="larmatch_ckpt78k.pt"
-LARPID_MODEL="${LARPID_DIR}/LArPID_default_network_weights.pt"
+LARPID_MODEL="${LARPID_DIR}/LArPID_alternate_network_weights.pt"
 
 echo "larsoftout: $larsoftout"
 echo "baseinput: $baseinput"
@@ -76,11 +76,11 @@ CMD="python3 $LARMATCH_DIR/deploy_larmatchme.py --config-file ${CONFIG_FILE} --s
 echo $CMD
 $CMD
 
-CMD="python3 $RECO_TEST_DIR/run_kpsrecoman.py --input-dlmerged ${baseinput} --input-larflow ${baselm} --output ${reco_outfile} -mc --products min --save-all-keypoints --loglevel 3"
+CMD="python3 $RECO_TEST_DIR/run_kpsrecoman.py --input-dlmerged ${baseinput} --input-larflow ${baselm} --output ${reco_outfile} --products min --save-all-keypoints --loglevel 3"
 echo $CMD
 $CMD
 
-CMD="python3 $NTMAKER_DIR/make_dlgen2_flat_ntuples.py -f ${reco_basename}_kpsrecomanagerana.root -t $baseinput -o $ntuple_outfile -m $LARPID_MODEL -mc --ignoreWeights --noEvtSkipping"
+CMD="python3 $NTMAKER_DIR/make_dlgen2_flat_ntuples.py -f ${reco_basename}_kpsrecomanagerana.root -t $baseinput -o $ntuple_outfile -m $LARPID_MODEL --ignoreWeights --noEvtSkipping"
 echo $CMD
 $CMD
 

--- a/ubcv/LArCVImageMaker/mcc10_prod_scripts/run_lantern_workflow_mc_altLArPIDWeights.sh
+++ b/ubcv/LArCVImageMaker/mcc10_prod_scripts/run_lantern_workflow_mc_altLArPIDWeights.sh
@@ -38,7 +38,7 @@ larsoftout=$(find . -maxdepth 1 -type f -name 'merged_dlreco*.root' -printf '%f\
 baseinput="merged_dlreco_with_ssnet.root"
 CONFIG_FILE="${LANTERN_SCRIPTS}/config_larmatchme_deploycpu.yaml"
 WEIGHT_FILE="larmatch_ckpt78k.pt"
-LARPID_MODEL="${LARPID_DIR}/LArPID_default_network_weights.pt"
+LARPID_MODEL="${LARPID_DIR}/LArPID_alternate_network_weights.pt"
 
 echo "larsoftout: $larsoftout"
 echo "baseinput: $baseinput"
@@ -72,7 +72,7 @@ for tree in $inputTrees; do
   rootcp ssnet_ubspurn_output.root:${tree} ${baseinput}
 done
 
-CMD="python3 $LARMATCH_DIR/deploy_larmatchme.py --config-file ${CONFIG_FILE} --supera $baseinput --weights ${LARMATCH_DIR}/${WEIGHT_FILE} --output $lm_outfile --min-score 0.5 --adc-name wire --chstatus-name wire --device-name cpu --use-skip-limit"
+CMD="python3 $LARMATCH_DIR/deploy_larmatchme.py --config-file ${CONFIG_FILE} --supera $baseinput --weights ${LARMATCH_DIR}/${WEIGHT_FILE} --output $lm_outfile --min-score 0.5 --adc-name wire --chstatus-name wire --device-name cpu"
 echo $CMD
 $CMD
 


### PR DESCRIPTION
What was done:
-  create `launch_lantern_container_data_unified_altLArPIDWeights.sh`  to be able to run on Run 3 data
-  updated the running scripts (e.g. `run_lantern_workflow_mc.sh`, ` run_lantern_workflow_mc_altLArPIDWeights.sh`, ...)  which the launch scripts call. this is just to version control the versions that are in the lantern container. the copies of the run scripts in this repo are NOT run during production. Instead what is run during production jobs are the copies of these scripts in the container in `/cluster/home/lantern_scripts/`.